### PR TITLE
fix typo start_with is starts_with

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you're not using one of those options for opening the project, then you'll ne
 
 3. Click 'http://127.0.0.1:3100' in the terminal, which should open a new tab in the browser.
 
-4. Try the API at '/generate_name' and try passing in a parameter at the end of the URL, like '/generate_name?start_with=N'.
+4. Try the API at '/generate_name' and try passing in a parameter at the end of the URL, like '/generate_name?starts_with=N'.
 
 ### Local development with Docker
 


### PR DESCRIPTION
Thank you for the great sample. This is helpful for Python beginners.

In README.md, it is start_with. but in the function arguments, starts_with.

https://github.com/pamelafox/simple-fastapi-container/blob/6751d2d1ebc4400dc637a822e673e5d29acada2f/README.md?plain=1#L40

https://github.com/pamelafox/simple-fastapi-container/blob/6751d2d1ebc4400dc637a822e673e5d29acada2f/src/api/main.py#L11

