### PR TITLE
Remove pre-commit install in postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
 	"forwardPorts": [3100],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "python3 -m pip install -r requirements-dev.txt && pre-commit install",
+	"postCreateCommand": "python3 -m pip install -r requirements-dev.txt",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"


### PR DESCRIPTION
Fixes #42

This pull request includes a change to the `postCreateCommand` in the `.devcontainer/devcontainer.json` file. The command `pre-commit install` has been removed from the `postCreateCommand`, which means that pre-commit hooks will no longer be automatically installed after the container is created. It occasionally causes issues for folks who arent in a git repo.